### PR TITLE
Upgrade to v2025.02.05 and fix github workflow on_upstream

### DIFF
--- a/.github/workflows/ynh-build-on-push-to-testing.yml
+++ b/.github/workflows/ynh-build-on-push-to-testing.yml
@@ -27,7 +27,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          files: ${{ steps.build_release.outputs.YNH_ARCHIVE }}
+          files: ${{ steps.build_release.outputs.YNH_RELEASE_FILE }}
           tag_name: v${{ steps.pr_data.outputs.VERSION }}
           draft: true
           prerelease: false

--- a/.github/workflows/ynh-build-on-upstream-update.yml
+++ b/.github/workflows/ynh-build-on-upstream-update.yml
@@ -36,7 +36,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          files: ${{ steps.build_release.outputs.YNH_ARCHIVE }}
+          files: ${{ steps.build_release.outputs.YNH_RELEASE_FILE }}
           fail_on_unmatched_files: true
           tag_name: v${{ steps.pr_data.outputs.VERSION }}
           draft: true
@@ -47,21 +47,11 @@ jobs:
             ### Changelog
             Cf. upstream release note: ${{ steps.pr_data.outputs.URL }}
 
-      - name: Download built file
-        run: |
-          download_url=$(echo "${{fromJson(steps.draft_release.outputs.assets)[0].browser_download_url}}")
-          wget $download_url -O release_asset
-
-      - name: Compute SHA256 sum of the asset
-        id: compute_sha256
-        run: |
-          echo "SHASUM=$(sha256sum release_asset | awk '{ print $1 }')" >> "$GITHUB_OUTPUT"
-
       - name: Replace URL & SHA256 in manifest.toml
         run: |
           sed -i -e '|\[resources.sources.ynh_build\]|,|sha256|!b' \
-              -i -e '|url|s|=.*$|= "${{ steps.draft_release.outputs.url }}"|' \
-              -i -e '|sha256|s|=.*$|= "${{ steps.compute_sha256.outputs.SHASUM }}"|' \
+              -i -e '|url|s|=.*$|= "${{ steps.build_release.outputs.YNH_RELEASE_URL }}"|' \
+              -i -e '|sha256|s|=.*$|= "${{ steps.build_release.outputs.YNH_RELEASE_SHA }}"|' \
               manifest.toml
 
       - name: Commit changes to manifest.toml

--- a/PACKAGE_UPDATE.md
+++ b/PACKAGE_UPDATE.md
@@ -1,8 +1,8 @@
 ### Specific upgrade steps
 
 - [ ] `/scripts/build` is still working for new upstream version or it was fixed in accordance with upstream commits diffs.
-- [ ] A build action for this version was successfully completed in the Action tabs.
-- [ ] A new [release](https://github.com/YunoHost-Apps/jsoncrack_ynh/releases) was published with the new build attached 
+- [ ] A build action for this version is successfully completed in the [Action](https://github.com/YunoHost-Apps/jsoncrack_ynh/actions) tabs.
+- [ ] A new [release](https://github.com/YunoHost-Apps/jsoncrack_ynh/releases) is published with the new build attached 
 - [ ] `url` and `sha256` fields under `[resources.sources.ynh_build]` section in `manifest.toml` are updated to meet the file attached in the new release.
 - [ ] CI test is successful
 

--- a/PACKAGE_UPDATE.md
+++ b/PACKAGE_UPDATE.md
@@ -1,0 +1,9 @@
+### Specific upgrade steps
+
+- [ ] `/scripts/build` is still working for new upstream version or it was fixed in accordance with upstream commits diffs.
+- [ ] A build action for this version was successfully completed in the Action tabs.
+- [ ] A new [release](https://github.com/YunoHost-Apps/jsoncrack_ynh/releases) was published with the new build attached 
+- [ ] `url` and `sha256` fields under `[resources.sources.ynh_build]` section in `manifest.toml` are updated to meet the file attached in the new release.
+- [ ] CI test is successful
+
+Read this app's specific [upgrade documentation](https://github.com/YunoHost-Apps/jsoncrack_ynh/wiki/How-to-apply-upstream-upgrades-to-this-package) for more information.

--- a/PACKAGE_UPDATE.md
+++ b/PACKAGE_UPDATE.md
@@ -3,7 +3,7 @@
 - [ ] `/scripts/build` is still working for new upstream version or it was fixed in accordance with upstream commits diffs.
 - [ ] A build action for this version is successfully completed in the [Action](https://github.com/YunoHost-Apps/jsoncrack_ynh/actions) tabs.
 - [ ] A new [release](https://github.com/YunoHost-Apps/jsoncrack_ynh/releases) is published with the new build attached 
-- [ ] `url` and `sha256` fields under `[resources.sources.ynh_build]` section in `manifest.toml` are updated to meet the file attached in the new release.
+- [ ] `url` and `sha256` fields under `[resources.sources.ynh_build]` section in `manifest.toml` are updated to match the file attached in the new release.
 - [ ] CI test is successful
 
 Read this app's specific [upgrade documentation](https://github.com/YunoHost-Apps/jsoncrack_ynh/wiki/How-to-apply-upstream-upgrades-to-this-package) for more information.

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ JSON Crack is a tool for visualizing JSON, YAML, CSV, XML, and TOML data in inte
 - Privacy: All data processing is performed client-side; nothing is stored on the server.
 
 
-**Shipped version:** 2024.12.12~ynh6
+**Shipped version:** 2024.12.12~ynh7
 
 **Demo:** <https://jsoncrack.com/editor>
 

--- a/README_es.md
+++ b/README_es.md
@@ -29,7 +29,7 @@ JSON Crack is a tool for visualizing JSON, YAML, CSV, XML, and TOML data in inte
 - Privacy: All data processing is performed client-side; nothing is stored on the server.
 
 
-**Versión actual:** 2024.12.12~ynh6
+**Versión actual:** 2024.12.12~ynh7
 
 **Demo:** <https://jsoncrack.com/editor>
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -29,7 +29,7 @@ JSON Crack is a tool for visualizing JSON, YAML, CSV, XML, and TOML data in inte
 - Privacy: All data processing is performed client-side; nothing is stored on the server.
 
 
-**Paketatutako bertsioa:** 2024.12.12~ynh6
+**Paketatutako bertsioa:** 2024.12.12~ynh7
 
 **Demoa:** <https://jsoncrack.com/editor>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -29,7 +29,7 @@ JSON Crack est un outil pour visualiser des données JSON, YAML, CSV, XML et TOM
 - Confidentialité: Traitement des données côté client, rien n'est enregistré sur le serveur.
 
 
-**Version incluse :** 2024.12.12~ynh6
+**Version incluse :** 2024.12.12~ynh7
 
 **Démo :** <https://jsoncrack.com/editor>
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -29,7 +29,7 @@ JSON Crack is a tool for visualizing JSON, YAML, CSV, XML, and TOML data in inte
 - Privacy: All data processing is performed client-side; nothing is stored on the server.
 
 
-**Versión proporcionada:** 2024.12.12~ynh6
+**Versión proporcionada:** 2024.12.12~ynh7
 
 **Demo:** <https://jsoncrack.com/editor>
 

--- a/README_id.md
+++ b/README_id.md
@@ -29,7 +29,7 @@ JSON Crack is a tool for visualizing JSON, YAML, CSV, XML, and TOML data in inte
 - Privacy: All data processing is performed client-side; nothing is stored on the server.
 
 
-**Versi terkirim:** 2024.12.12~ynh6
+**Versi terkirim:** 2024.12.12~ynh7
 
 **Demo:** <https://jsoncrack.com/editor>
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -29,7 +29,7 @@ JSON Crack is a tool for visualizing JSON, YAML, CSV, XML, and TOML data in inte
 - Privacy: All data processing is performed client-side; nothing is stored on the server.
 
 
-**Geleverde versie:** 2024.12.12~ynh6
+**Geleverde versie:** 2024.12.12~ynh7
 
 **Demo:** <https://jsoncrack.com/editor>
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -29,7 +29,7 @@ JSON Crack is a tool for visualizing JSON, YAML, CSV, XML, and TOML data in inte
 - Privacy: All data processing is performed client-side; nothing is stored on the server.
 
 
-**Dostarczona wersja:** 2024.12.12~ynh6
+**Dostarczona wersja:** 2024.12.12~ynh7
 
 **Demo:** <https://jsoncrack.com/editor>
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -29,7 +29,7 @@ JSON Crack is a tool for visualizing JSON, YAML, CSV, XML, and TOML data in inte
 - Privacy: All data processing is performed client-side; nothing is stored on the server.
 
 
-**Поставляемая версия:** 2024.12.12~ynh6
+**Поставляемая версия:** 2024.12.12~ynh7
 
 **Демо-версия:** <https://jsoncrack.com/editor>
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -29,7 +29,7 @@ JSON Crack is a tool for visualizing JSON, YAML, CSV, XML, and TOML data in inte
 - Privacy: All data processing is performed client-side; nothing is stored on the server.
 
 
-**分发版本：** 2024.12.12~ynh6
+**分发版本：** 2024.12.12~ynh7
 
 **演示：** <https://jsoncrack.com/editor>
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "JSON Crack"
 description.en = "Data visualization app for JSON, YAML, XML, CSV formats and more"
 description.fr = "Application de visualisation de données pour les formats JSON, YAML, XML, CSV et autres"
 
-version = "2024.12.12~ynh6"
+version = "2024.12.12~ynh7"
 
 maintainers = ["oleole39"]
 
@@ -49,8 +49,8 @@ ram.runtime = "0M"
 
         [resources.sources.upstream]
         # This is not used as we are using git clone. It's only here for autoupdate.
-        url = "https://github.com/AykutSarac/jsoncrack.com/archive/dd764638a5e6d4a3af74254195aecd55c083c9af.tar.gz"
-        sha256 = "5eb018c37ede287398f444068567d671f18fb08bff305736fb34ed8dbbc0efe9"
+        url = "https://github.com/AykutSarac/jsoncrack.com/archive/edd723818372c9aa610ab9e57b26dace02853962.tar.gz"
+        sha256 = "dd1171bdff85931fadc29a51ce2ac448ce965f88e8673bdf823308d38462a70c"
         prefetch = false
         autoupdate.strategy = "latest_github_commit"
 

--- a/scripts/build
+++ b/scripts/build
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 #=================================================
-# BUILD SCRIPT RESOURCES USAGE:
-# Up to 1.5GB disk space and 4GB RAM. 
+# THIS BUILD SCRIPT RESOURCES USAGE:
+# ~1.5GB disk space and 4GB RAM. 
 #=================================================
 
 set -x
@@ -25,14 +25,16 @@ gh_personal_token=""
 if [[ $source_type == "release" ]]; then
     last_upstream_version=$(curl --silent "https://api.github.com/repos/${upstream_owner}/${upstream_repo}/releases/latest" | grep -Po "(?<=\"tag_name\": \").*(?=\")")
     download_url="https://api.github.com/repos/${upstream_owner}/${upstream_repo}/tarball/${last_upstream_version}"
-    build_folder="${upstream_repo}_${last_upstream_version}"
+    build_folder="${upstream_repo}_${last_upstream_version}" #e.g. jsoncrack_ynh_v3.2.0
+    release_version="${last_upstream_version}"
 else
     last_upstream_version=$(curl --silent "https://api.github.com/repos/${upstream_owner}/${upstream_repo}/commits/${upstream_branch}" | grep -Po "(?<=\"sha\": \").*(?=\")" | head -n 1) #e.g. d5f9bfc7fba1f1908863390f16ba28589d84a7d5
     last_upstream_version_short=${last_upstream_version:0:8}
     last_date_tag=$(curl --silent "https://api.github.com/repos/${upstream_owner}/${upstream_repo}/commits/${upstream_branch}" | grep -Po "(?<=\"verified_at\": \").*(?=\")" | head -n 1) #e.g. 2024-11-19T18:37:03Z
     last_date_tag_short=$(echo ${last_date_tag:0:10} | sed 's/-/./g') #e.g. 2024.11.19
     download_url="https://github.com/${upstream_owner}/${upstream_repo}/archive/${last_upstream_version}.tar.gz"
-    build_folder="${upstream_repo}_v${last_date_tag_short}_${last_upstream_version_short}" #e.g. jsoncrack.com_v.2024.11.19-d5f9bfc7
+    build_folder="${upstream_repo}_v${last_date_tag_short}_${last_upstream_version_short}" #e.g. jsoncrack.com_v2024.11.19-d5f9bfc7
+    release_version="{$last_upstream_version_short}"
 fi
 curl -LJ $download_url --output "${build_folder}.tar.gz"
 mkdir "$build_folder"
@@ -96,7 +98,7 @@ popd
 #=================================================
 # BUILD
 #=================================================
-ynh_archive_name="${build_folder}_ynh.zip"
+ynh_release_filename="${build_folder}_ynh.zip"
 pushd "$build_folder"
     # Call NVM if expected node version differs form current node version
     current_node_version=$(node -v | cut -c 2- | cut -c 1-${#build_node_version})
@@ -116,9 +118,11 @@ pushd "$build_folder"
 
     # Package   
     mv "${default_build_folder}" "${ynh_repo}"
-    zip -r $ynh_archive_name "${ynh_repo}"
-    mv $ynh_archive_name "../${ynh_archive_name}"
+    zip -r $ynh_release_filename "${ynh_repo}"
+    mv $ynh_release_filename "../${ynh_release_filename}"
 popd
+ynh_release_SHA=$(sha256sum ${ynh_release_filename} | cut -d' ' -f1)
+ynh_release_URL="https://github.com/${ynh_owner}/${ynh_repo}/releases/download/${release_version}/${ynh_release_filename}"
 
 #=================================================
 # CLEAN BUILD FOLDER
@@ -135,7 +139,7 @@ if [[ $gh_personal_token && -z $GITHUB_OUTPUT ]]; then
     
     echo "Trying to upload the release to https://github.com/${ynh_owner}/${ynh_repo}/releases/ ..."
 
-    sha256sumarchive=$(sha256sum "$ynh_archive_name" | cut -d' ' -f1)
+    sha256sumarchive=$(sha256sum "$ynh_release_filename" | cut -d' ' -f1)
 
     if [[ "$@" =~ "push_release" ]]
     then
@@ -162,7 +166,7 @@ if [[ $gh_personal_token && -z $GITHUB_OUTPUT ]]; then
         # $upload_generic is like:
         # "upload_url": "https://uploads.github.com/repos/:owner/:repo/releases/:ID/assets{?name,label}",
         upload_prefix=$(echo $upload_generic | cut -d "\"" -f4 | cut -d "{" -f1)
-        upload_file="$upload_prefix?name=$ynh_archive_name"
+        upload_file="$upload_prefix?name=$ynh_release_filename"
 
         echo "Start uploading first file"
         i=0
@@ -172,9 +176,9 @@ if [[ $gh_personal_token && -z $GITHUB_OUTPUT ]]; then
             # Download file
             set +e
             succ=$(curl -H "Authorization: token $gh_personal_token" \
-                -H "Content-Type: $(file -b --mime-type $ynh_archive_name)" \
+                -H "Content-Type: $(file -b --mime-type $ynh_release_filename)" \
                 -H "Accept: application/vnd.github.v3+json" \
-                --data-binary @$ynh_archive_name $upload_file)
+                --data-binary @$ynh_release_filename $upload_file)
             res=$?
             set -e
             if [ $res -ne 0 ]; then
@@ -210,7 +214,11 @@ if [[ $gh_personal_token && -z $GITHUB_OUTPUT ]]; then
 
 # Script run with Github Workflow or with empty $gh_personal_token
 else
-    if [[ $GITHUB_OUTPUT ]]; then echo "YNH_ARCHIVE=${ynh_archive_name}" >> $GITHUB_OUTPUT; fi #export var for Github Workflow
+    if [[ $GITHUB_OUTPUT ]]; then 
+		echo "YNH_RELEASE_FILE=${ynh_release_filename}" >> $GITHUB_OUTPUT
+		echo "YNH_RELEASE_SHA=${ynh_release_SHA}" >> $GITHUB_OUTPUT
+		echo "YNH_RELEASE_URL=${ynh_release_URL}" >> $GITHUB_OUTPUT
+	fi #export var for Github Workflow
     echo "Build completed but not uploaded - missing Github Token"
     set +x 
 fi

--- a/scripts/build
+++ b/scripts/build
@@ -215,10 +215,10 @@ if [[ $gh_personal_token && -z $GITHUB_OUTPUT ]]; then
 # Script run with Github Workflow or with empty $gh_personal_token
 else
     if [[ $GITHUB_OUTPUT ]]; then 
-		echo "YNH_RELEASE_FILE=${ynh_release_filename}" >> $GITHUB_OUTPUT
-		echo "YNH_RELEASE_SHA=${ynh_release_SHA}" >> $GITHUB_OUTPUT
-		echo "YNH_RELEASE_URL=${ynh_release_URL}" >> $GITHUB_OUTPUT
-	fi #export var for Github Workflow
+        echo "YNH_RELEASE_FILE=${ynh_release_filename}" >> $GITHUB_OUTPUT
+        echo "YNH_RELEASE_SHA=${ynh_release_SHA}" >> $GITHUB_OUTPUT
+        echo "YNH_RELEASE_URL=${ynh_release_URL}" >> $GITHUB_OUTPUT
+    fi #export var for Github Workflow
     echo "Build completed but not uploaded - missing Github Token"
     set +x 
 fi


### PR DESCRIPTION
Upgrade sources
- `upstream` v2025.02.05: https://github.com/AykutSarac/jsoncrack.com/compare/dd764638a5e6d4a3af74254195aecd55c083c9af...edd723818372c9aa610ab9e57b26dace02853962

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
