### PR TITLE
Update to v2025.03.13-3e9d2f58

### DIFF
--- a/.github/workflows/ynh-build-on-demand.yml
+++ b/.github/workflows/ynh-build-on-demand.yml
@@ -58,7 +58,6 @@ jobs:
           PR_URL="$(gh pr list --head ${CURRENT_BRANCH_NAME} --state open --json url --jq .[].url)"
           PR_BODY="Upstream upgrade is now built for YNH and ready to be released in the current repository: ${{ steps.draft_release.outputs.url }}\n
           - [ ] Make sure the release is published before testing this PR.\n
-          - [ ] Rename PR title with appropriate version number.\n
           "
           if [[ -n "${PR_URL}" ]]; then
             echo "Editing already existing PR for the current branch -> ${PR_URL}"

--- a/.github/workflows/ynh-build-on-demand.yml
+++ b/.github/workflows/ynh-build-on-demand.yml
@@ -36,7 +36,7 @@ jobs:
           body: |
             Version built for Yunohost using `scripts/build` and `.github/workflows/ynh-build-on-demand.yml` in order to split upstream website from the app and ensure sub-directory install compatibility.
             ### Changelog
-            Cf. upstream release note: ${{ steps.diff_url.outputs.COMPARE_URL }}
+            Cf. upstream release note: ${{ steps.diff_url.outputs.YNH_RELEASE_DIFF_COMPARE_URL }}
 
       - name: Replace URL & SHA256 in manifest.toml
         run: |

--- a/.github/workflows/ynh-build-on-push-to-testing.yml
+++ b/.github/workflows/ynh-build-on-push-to-testing.yml
@@ -37,7 +37,7 @@ jobs:
           body: |
             Version built for Yunohost using `scripts/build` and `.github/workflows/ynh-build-on-push-to-testing.yml` in order to split upstream website from the app and ensure sub-directory install compatibility.
             ### Changelog
-            Cf. upstream release note: ${{ steps.diff_url.outputs.COMPARE_URL }}
+            Cf. upstream release note: ${{ steps.diff_url.outputs.YNH_RELEASE_DIFF_COMPARE_URL }}
 
       - name: Replace URL & SHA256 in manifest.toml
         run: |

--- a/.github/workflows/ynh-build-on-push-to-testing.yml
+++ b/.github/workflows/ynh-build-on-push-to-testing.yml
@@ -59,7 +59,6 @@ jobs:
           PR_URL="$(gh pr list --head ${CURRENT_BRANCH_NAME} --state open --json url --jq .[].url)"
           PR_BODY="Upstream upgrade is now built for YNH and ready to be released in the current repository: ${{ steps.draft_release.outputs.url }}\n
           - [ ] Make sure the release is published before testing this PR.\n
-          - [ ] Rename PR title with appropriate version number.\n
           "
           if [[ -n "${PR_URL}" ]]; then
             echo "Editing already existing PR for the current branch -> ${PR_URL}"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ JSON Crack is a tool for visualizing JSON, YAML, CSV, XML, and TOML data in inte
 - Privacy: All data processing is performed client-side; nothing is stored on the server.
 
 
-**Shipped version:** 2024.12.12~ynh7
+**Shipped version:** 2024.12.12~ynh8
 
 **Demo:** <https://jsoncrack.com/editor>
 

--- a/README_es.md
+++ b/README_es.md
@@ -29,7 +29,7 @@ JSON Crack is a tool for visualizing JSON, YAML, CSV, XML, and TOML data in inte
 - Privacy: All data processing is performed client-side; nothing is stored on the server.
 
 
-**Versión actual:** 2024.12.12~ynh7
+**Versión actual:** 2024.12.12~ynh8
 
 **Demo:** <https://jsoncrack.com/editor>
 

--- a/README_eu.md
+++ b/README_eu.md
@@ -29,7 +29,7 @@ JSON Crack is a tool for visualizing JSON, YAML, CSV, XML, and TOML data in inte
 - Privacy: All data processing is performed client-side; nothing is stored on the server.
 
 
-**Paketatutako bertsioa:** 2024.12.12~ynh7
+**Paketatutako bertsioa:** 2024.12.12~ynh8
 
 **Demoa:** <https://jsoncrack.com/editor>
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -29,7 +29,7 @@ JSON Crack est un outil pour visualiser des données JSON, YAML, CSV, XML et TOM
 - Confidentialité: Traitement des données côté client, rien n'est enregistré sur le serveur.
 
 
-**Version incluse :** 2024.12.12~ynh7
+**Version incluse :** 2024.12.12~ynh8
 
 **Démo :** <https://jsoncrack.com/editor>
 

--- a/README_gl.md
+++ b/README_gl.md
@@ -29,7 +29,7 @@ JSON Crack is a tool for visualizing JSON, YAML, CSV, XML, and TOML data in inte
 - Privacy: All data processing is performed client-side; nothing is stored on the server.
 
 
-**Versión proporcionada:** 2024.12.12~ynh7
+**Versión proporcionada:** 2024.12.12~ynh8
 
 **Demo:** <https://jsoncrack.com/editor>
 

--- a/README_id.md
+++ b/README_id.md
@@ -29,7 +29,7 @@ JSON Crack is a tool for visualizing JSON, YAML, CSV, XML, and TOML data in inte
 - Privacy: All data processing is performed client-side; nothing is stored on the server.
 
 
-**Versi terkirim:** 2024.12.12~ynh7
+**Versi terkirim:** 2024.12.12~ynh8
 
 **Demo:** <https://jsoncrack.com/editor>
 

--- a/README_nl.md
+++ b/README_nl.md
@@ -29,7 +29,7 @@ JSON Crack is a tool for visualizing JSON, YAML, CSV, XML, and TOML data in inte
 - Privacy: All data processing is performed client-side; nothing is stored on the server.
 
 
-**Geleverde versie:** 2024.12.12~ynh7
+**Geleverde versie:** 2024.12.12~ynh8
 
 **Demo:** <https://jsoncrack.com/editor>
 

--- a/README_pl.md
+++ b/README_pl.md
@@ -29,7 +29,7 @@ JSON Crack is a tool for visualizing JSON, YAML, CSV, XML, and TOML data in inte
 - Privacy: All data processing is performed client-side; nothing is stored on the server.
 
 
-**Dostarczona wersja:** 2024.12.12~ynh7
+**Dostarczona wersja:** 2024.12.12~ynh8
 
 **Demo:** <https://jsoncrack.com/editor>
 

--- a/README_ru.md
+++ b/README_ru.md
@@ -29,7 +29,7 @@ JSON Crack is a tool for visualizing JSON, YAML, CSV, XML, and TOML data in inte
 - Privacy: All data processing is performed client-side; nothing is stored on the server.
 
 
-**Поставляемая версия:** 2024.12.12~ynh7
+**Поставляемая версия:** 2024.12.12~ynh8
 
 **Демо-версия:** <https://jsoncrack.com/editor>
 

--- a/README_zh_Hans.md
+++ b/README_zh_Hans.md
@@ -29,7 +29,7 @@ JSON Crack is a tool for visualizing JSON, YAML, CSV, XML, and TOML data in inte
 - Privacy: All data processing is performed client-side; nothing is stored on the server.
 
 
-**分发版本：** 2024.12.12~ynh7
+**分发版本：** 2024.12.12~ynh8
 
 **演示：** <https://jsoncrack.com/editor>
 

--- a/manifest.toml
+++ b/manifest.toml
@@ -56,7 +56,7 @@ ram.runtime = "0M"
 
         [resources.sources.ynh_build]
         url = "https://github.com/Yunohost-Apps/jsoncrack_ynh/releases/download/v2025.03.13-3e9d2f58/jsoncrack.com_v2025.03.13-3e9d2f58_ynh.zip"
-        sha256 = "81ed0fd59423c73db2070b3c4186a6cf27cd63ebe469b8f546e14141235f9bdb"
+        sha256 = "45ef28e96cfb7f333ee896cd7e358c267115a8fe731154148c7e4e33b4138a94"
         format = "zip"
         extract = true
         in_subdir = true

--- a/manifest.toml
+++ b/manifest.toml
@@ -5,7 +5,7 @@ name = "JSON Crack"
 description.en = "Data visualization app for JSON, YAML, XML, CSV formats and more"
 description.fr = "Application de visualisation de données pour les formats JSON, YAML, XML, CSV et autres"
 
-version = "2024.12.12~ynh7"
+version = "2024.12.12~ynh8"
 
 maintainers = ["oleole39"]
 
@@ -49,14 +49,14 @@ ram.runtime = "0M"
 
         [resources.sources.upstream]
         # This is not used as we are using git clone. It's only here for autoupdate.
-        url = "https://github.com/AykutSarac/jsoncrack.com/archive/f0b2a1d3a2030f4f61d151183a3b579ea2775bd3.tar.gz"
-        sha256 = "a4bf4f10ed0fc7a11cdb826e7b823224d7120dd438a9691ad76765abebeb0198"
+        url = "https://github.com/AykutSarac/jsoncrack.com/archive/3e9d2f583c6012ab86f996e5b5a6c2121fc08823.tar.gz"
+        sha256 = "bdbbe30abeff60b46470a7701e79aac35da8318e7a1523377d3cf646e6ef04a3"
         prefetch = false
         autoupdate.strategy = "latest_github_commit"
 
         [resources.sources.ynh_build]
-        url = "https://github.com/Yunohost-Apps/jsoncrack_ynh/releases/download/v2025.03.11_ff0b435b/jsoncrack.com_v2025.03.11_ff0b435b_ynh.zip"
-        sha256 = "6cfb84383ef3a987d2a1a871ecd5d2ca0b22bde0cf32276a6348c3c42db8b820"
+        url = "https://github.com/Yunohost-Apps/jsoncrack_ynh/releases/download/v2025.03.13-3e9d2f58/jsoncrack.com_v2025.03.13-3e9d2f58_ynh.zip"
+        sha256 = "81ed0fd59423c73db2070b3c4186a6cf27cd63ebe469b8f546e14141235f9bdb"
         format = "zip"
         extract = true
         in_subdir = true

--- a/scripts/build
+++ b/scripts/build
@@ -44,10 +44,8 @@ tar --strip-components=1 -xvf "${build_folder}.tar.gz" -C "./${build_folder}/"
 # Adapt for YNH context and remove calls for upgrading to premium (support encouraged via 'fund' parameter in the manifest.toml)
 pushd "$build_folder"
     # Remove calls to premium
-    sed -i '/{!isWidget/{:Loop;N;/\n\s*)}/!bLoop;/UpgradeModal/d}' "./src/features/editor/Toolbar/index.tsx"             # Remove call to Premium (removes block delimited with START='{!isWidget' and END='\n\s*)}' which contains TARGET='todiagram.com'). 
+    sed -i '/<Button/{:Loop;N;/\n\s*<\/Button>/!bLoop;/UpgradeModal/d}' "./src/features/editor/Toolbar/index.tsx"        # Remove call to Premium (removes block delimited with START='{!isWidget' and END='\n\s*)}' which contains TARGET='todiagram.com'). 
     sed -i '/setVisible/d' "./src/features/editor/Toolbar/index.tsx"                                                     # Remove now unused var
-    sed -i '/<Button/{:Loop;N;/\n\s*<\/Button>/!bLoop;/UpgradeModal/d}' "./src/features/modals/NodeModal/index.tsx"      # Remove listed premium options (removes all blocks delimited with START='<Button' and END='\n\s*</Button>' which contains TARGET='upgrade'). 
-    sed -i '/const setVisible/d' "./src/features/modals/NodeModal/index.tsx"                                             # Remove related const declaration to avoid lint error
     sed -i 's/Cookie.get("upgrade_shown")/true/g' "./src/pages/editor.tsx"                                               # Remove call for premium when opened for the first time or after cookie expiry. --> EDIT: Should not be necessary anymore since that commit: https://github.com/AykutSarac/jsoncrack.com/commit/d614bf9d67fabe7c8110027442dd76ee05ba6be2 
     sed -i '/ExternalMode/d' "./src/pages/editor.tsx"                                                                    # Remove call for premium when executed not from official domain
     sed -i '/if (aboveSupportedLimit) {/,/}/d' "./src/features/editor/views/GraphView/index.tsx"                         # Remove call for premium when reaching a graph limitation (full block to avoid compilation error)


### PR DESCRIPTION
Upstream upgrade is now built for YNH and ready to be released in the current repository: https://github.com/YunoHost-Apps/jsoncrack_ynh/releases/tag/untagged-c25029d419308f7070bc
 - [ ] Make sure the release is published before testing this PR.

